### PR TITLE
Updates Python and Node dependencies

### DIFF
--- a/{{cookiecutter.python_name}}/binder/environment.yml
+++ b/{{cookiecutter.python_name}}/binder/environment.yml
@@ -11,10 +11,10 @@ channels:
 
 dependencies:
   # runtime dependencies
-  - python >=3.8,<3.9.0a0
+  - python >=3.10,<3.11.0a0
   - jupyterlab >=3,<4.0.0a0
   # labextension build dependencies
-  - nodejs >=14,<15
+  - nodejs >=18,<19
   - pip
   - wheel
   # additional packages for demos


### PR DESCRIPTION
Updates the Python dependency for new JS extensions to 3.10.x. Updates the Node dependency from 14 to 18 (both 14 and 16 reach end-of-life this year).

See also https://github.com/jupyterlab/extension-cookiecutter-ts/pull/271.